### PR TITLE
fixed visibility of the `Eunit\Cases\Unit_Test::$factory` prop

### DIFF
--- a/src/cases/unit-test.php
+++ b/src/cases/unit-test.php
@@ -26,7 +26,7 @@ abstract class Unit_Test extends \WP_UnitTestCase {
 	/**
 	 * @var WP_UnitTest_Factory|null
 	 */
-	private $factory;
+	protected $factory;
 
 	public function get_namespace() {
 		return getenv( 'EUNIT_TEST_CASE_NAMESPACE' );


### PR DESCRIPTION
```
Run phpunit -c phpunit.xml.dist --coverage-text --coverage-html=coverage --coverage-clover coverage/coverage.xml
Installing...
Running as single site... To run multisite, use -c tests/phpunit/multisite.xml
Not running ajax tests. To execute these, use --group ajax.
Not running ms-files tests. To execute these, use --group ms-files.
Not running external-http tests. To execute these, use --group external-http.
PHP Fatal error:  Access level to Eunit\Cases\Unit_Test::$factory must be protected (as in class WP_UnitTestCase) or weaker in /home/runner/work/elementor-account-dashboard/elementor-account-dashboard/src/wp-content/plugins/elementor-account-dashboard/vendor/elementor/eunit/src/cases/unit-test.php on line 34

Fatal error: Access level to Eunit\Cases\Unit_Test::$factory must be protected (as in class WP_UnitTestCase) or weaker in /home/runner/work/elementor-account-dashboard/elementor-account-dashboard/src/wp-content/plugins/elementor-account-dashboard/vendor/elementor/eunit/src/cases/unit-test.php on line 34
Error: Process completed with exit code 255.
```